### PR TITLE
Fix weekly-update workflow dispatch (invalid expression arithmetic)

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -124,8 +124,11 @@ jobs:
             fi
           done < <(jq -c '.[]' _niches_data.json)
 
+          success_count=$((total_niches - missing_count))
+
           echo "TOTAL_NICHES=$total_niches" >> $GITHUB_ENV
           echo "MISSING_COUNT=$missing_count" >> $GITHUB_ENV
+          echo "SUCCESS_COUNT=$success_count" >> $GITHUB_ENV
           echo -e "UPDATED_NICHES=$updated_niches" >> $GITHUB_ENV
       
       - name: Generate root index.html
@@ -169,7 +172,7 @@ jobs:
             
             ### Summary
             - **Total niches processed:** ${{ env.TOTAL_NICHES }}
-            - **Successfully updated:** ${{ env.TOTAL_NICHES - env.MISSING_COUNT }}
+            - **Successfully updated:** ${{ env.SUCCESS_COUNT }}
             - **Failed:** ${{ env.MISSING_COUNT }}
             
             ### Updated Sites


### PR DESCRIPTION
## Summary
- The `Weekly Niche Site Update` workflow (`.github/workflows/weekly-update.yml`) could not be dispatched manually because the PR-body template used `${{ env.TOTAL_NICHES - env.MISSING_COUNT }}`. GitHub Actions expressions do not support arithmetic operators, producing a parse error: `Unexpected symbol: '-'` at line 164.
- Fix computes `success_count = total_niches - missing_count` in the shell `Verify niche folders` step and exposes it as `env.SUCCESS_COUNT`, which the PR body now references.

This unblocks manual (`workflow_dispatch`) runs of the weekly product-data regeneration workflow.

## Testing
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes on the edited file.
- [ ] Manual `workflow_dispatch` of `weekly-update.yml` reaches the PR-creation step without expression errors (verify after merge to default branch, since dispatch reads the workflow from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)