### PR TITLE
Restore reliable automatic niche generation

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -1,9 +1,7 @@
 name: Weekly Niche Site Update
 
 on:
-  schedule:
-    # Run weekly on Monday at 6 AM UTC
-    - cron: '0 6 * * 1'
+  # Manual-only safety workflow. The main build workflow owns the weekly schedule.
   workflow_dispatch:
     inputs:
       niche:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ package-lock.json
 data/*.json
 !data/prices.json
 !data/reviews.json
+!data/niches-state.json
 
 # Temporary files
 *.tmp


### PR DESCRIPTION
## What changed

- allow `data/niches-state.json` to be committed while keeping other generated API-response JSON ignored
- remove the Monday schedule from `weekly-update.yml`, leaving it available for manual runs
- keep `build-sites.yml` as the single owner of the automatic weekly generation schedule

## Why

The incremental generator writes its persistent state to `data/niches-state.json`, but `.gitignore` excluded that file. Every clean GitHub Actions runner therefore started with empty state and could treat every niche as new, wasting API calls and increasing rate-limit and all-niches-failed risk.

Two independent workflows were also scheduled for the same Monday 06:00 UTC time, causing duplicate product fetching and competing repository updates.

## Expected impact

After the first successful state-producing build, unchanged niches can be skipped during incremental runs. Only the main build workflow will run automatically each week; the secondary PR-producing workflow remains available through manual dispatch.

## Validation

- branch is based on the latest `main`, including the merged invalid-expression fix from PR #81
- compared branch to `main`: exactly `.gitignore` and `.github/workflows/weekly-update.yml` changed
- branch is two commits ahead and zero commits behind

The first successful generator run must commit `data/niches-state.json`; subsequent incremental runs will then be able to reuse it.